### PR TITLE
Status bar icons color set to black when in light mode.

### DIFF
--- a/app/src/main/java/com/darshan/notificity/ui/theme/NotificityTheme.kt
+++ b/app/src/main/java/com/darshan/notificity/ui/theme/NotificityTheme.kt
@@ -1,5 +1,6 @@
 package com.darshan.notificity.ui.theme
 
+import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -8,7 +9,10 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 @Composable
 fun NotificityTheme(
@@ -24,6 +28,14 @@ fun NotificityTheme(
 
         darkTheme -> darkColorScheme()
         else -> lightColorScheme()
+    }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+        }
     }
 
     MaterialTheme(


### PR DESCRIPTION
Status bar icons color is set to black when in light mode and to white when in dark mode

## Before
![image](https://github.com/darshanpania/Notificity/assets/34279258/850a0d10-1ea1-4703-9593-6a4e2fb63081)
![image](https://github.com/darshanpania/Notificity/assets/34279258/36ce2a28-728c-45ce-8faa-d7803d712812)
![image](https://github.com/darshanpania/Notificity/assets/34279258/9f1e00ae-8135-4805-bf72-152395504933)
![image](https://github.com/darshanpania/Notificity/assets/34279258/12d73b34-4e33-489d-b61e-9a9fcc518af0)

## After
![image](https://github.com/darshanpania/Notificity/assets/34279258/98e83fa5-81b7-4ed5-81b7-c07490def1b5)
![image](https://github.com/darshanpania/Notificity/assets/34279258/52639a71-719b-4a50-89d5-c7affbcb3b8f)
![image](https://github.com/darshanpania/Notificity/assets/34279258/c0100eba-16c1-469a-9fc5-c1769efcac09)
![image](https://github.com/darshanpania/Notificity/assets/34279258/843e23ae-0b86-494c-8a87-50f1214193ef)
